### PR TITLE
Implement soft fitness support (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ require('timetabling-solver').minCollisions(data, config, callback, partialCallb
     constraints: [      // List of constraints
       constraint        // List of bookables which shouldn't overlap
     ]  
+    softFitness? = (timetable) // Optional, prioritizes between two equally fit solutions (smaller number -> more preferred)
   }
   config = {            // Object which contains extra configuration    
     iterations: 1000,   // Maximum number of generations before stopping the algorithm

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": "https://github.com/framp/timetabling-solver",
   "scripts": {
-    "test": "faucet",
+    "test": "node node_modules/tape/bin/tape tests/* | node node_modules/faucet/bin/cmd",
     "lint": "standard"
   },
   "dependencies": {

--- a/src/fitness.js
+++ b/src/fitness.js
@@ -2,7 +2,9 @@ const { table, findCollisions } = require('./helpers')
 
 module.exports = function (entity) {
   const constraints = this.userData.constraints
+  const softFitness = this.userData.softFitness || (timetable => 0);
   const timetable = table(...entity)
+
   return constraints.reduce((acc, constraint) =>
-    acc + findCollisions(timetable, constraint).length, 0)
+    acc + findCollisions(timetable, constraint).length, 0) + softFitness(timetable)
 }

--- a/src/mutate.js
+++ b/src/mutate.js
@@ -6,12 +6,14 @@ module.exports = function (entity) {
     entity[1].slice()
   ]
   const constraints = this.userData.constraints
+  const bookables = this.userData.bookables
   const timetable = table(...entity)
   const collisions = constraints.reduce((acc, constraint) =>
     acc.concat(findCollisions(timetable, constraint)), [])
-  const randomCollision =
+  const randomCollision = collisions.length > 0 ?
     collisions[Math.floor(Math.random() * collisions.length)]
-      .split(',')[Math.floor(Math.random() * 2)]
+      .split(',')[Math.floor(Math.random() * 2)] :
+    bookables[Math.floor(Math.random() * bookables.length)];
   const i = result[1].findIndex((bookable) => bookable === randomCollision)
   let j = Math.floor(Math.random() * (result[1].length - 1))
   if (j >= i) j++

--- a/tests/softFitness.test.js
+++ b/tests/softFitness.test.js
@@ -36,6 +36,7 @@ tape('softFitness influences results', (assert) => {
     iterations: 10,
     size: 3
   }, (table, fitness) => {
+    // according to softFitness set above, it will prefer that Tennis be at 8:00
     assert.deepEqual(table, { '8:00': ['Tennis'], '10:00': ['Climbing'] })
     assert.true(fitness.pop.filter((individual) => individual.fitness === 1).length >= 1)
   })

--- a/tests/softFitness.test.js
+++ b/tests/softFitness.test.js
@@ -31,12 +31,12 @@ tape('softFitness influences results', (assert) => {
   const constraints = [
     ['Tennis', 'Climbing'],
   ]
-  const softFitness = (timetable) => timetable['8:00'] == 'Tennis' ? 0 : 10;
+  const softFitness = (timetable) => timetable['8:00'] == 'Tennis' ? 1 : 10;
   solve({ slots, bookables, constraints, softFitness }, {
     iterations: 10,
     size: 3
   }, (table, fitness) => {
     assert.deepEqual(table, { '8:00': ['Tennis'], '10:00': ['Climbing'] })
-    assert.true(fitness.pop.filter((individual) => individual.fitness === 0).length >= 1)
+    assert.true(fitness.pop.filter((individual) => individual.fitness === 1).length >= 1)
   })
 })

--- a/tests/softFitness.test.js
+++ b/tests/softFitness.test.js
@@ -1,0 +1,42 @@
+const tape = require('tape')
+const fitness = require('../src/fitness')
+const helpers = require('../src/helpers')
+const solve = require('../src').minCollisions
+
+tape('softFitness works', (assert) => {
+  assert.plan(3)
+  const context = {
+    userData: {
+      helpers,
+      constraints: [
+        ['1', '7'],
+        ['2', '4', '8'],
+        ['3', '9']
+      ],
+      softFitness: (timetable) => timetable.a.reduce(
+        (acc, c) =>
+          acc + parseInt(c), 0
+      )
+    }
+  }
+  assert.equal(fitness.call(context, ['abcdef'.split(''), '213986754'.split('')]), 0 + 9)
+  assert.equal(fitness.call(context, ['abcdef'.split(''), '128456739'.split('')]), 1 + 8)
+  assert.equal(fitness.call(context, ['abcdef'.split(''), '123456789'.split('')]), 3 + 8)
+})
+
+tape('softFitness influences results', (assert) => {
+  assert.plan(2)
+  const slots = ['8:00', '10:00']
+  const bookables = ['Climbing', 'Tennis']
+  const constraints = [
+    ['Tennis', 'Climbing'],
+  ]
+  const softFitness = (timetable) => timetable['8:00'] == 'Tennis' ? 0 : 10;
+  solve({ slots, bookables, constraints, softFitness }, {
+    iterations: 10,
+    size: 3
+  }, (table, fitness) => {
+    assert.deepEqual(table, { '8:00': ['Tennis'], '10:00': ['Climbing'] })
+    assert.true(fitness.pop.filter((individual) => individual.fitness === 0).length >= 1)
+  })
+})


### PR DESCRIPTION
This PR adds an optional callback `softFitness` that allows one to specify preference between otherwise "equal" solutions. I.e. if there are multiple solutions that all have 0 collisions, we will return the one with smallest number calculated by this callback.